### PR TITLE
Add c++11 to build on aarch64

### DIFF
--- a/pkgs/apps/bodytrack/src/configure.ac
+++ b/pkgs/apps/bodytrack/src/configure.ac
@@ -72,6 +72,9 @@ CXXFLAGS="$CXXFLAGS -Wall"
 # Never warn about unknown pragmas
 CXXFLAGS="$CXXFLAGS -Wno-unknown-pragmas"
 
+# Always use c++11
+CXXFLAGS="$CXXFLAGS -std=c++11"
+
 # Make sure VPATH is always defined
 #if test "x$VPATH" == "x"; then
 #  VPATH="."


### PR DESCRIPTION
This is a PR to fix issue #6

qflex@qflex:~/parsec-benchmark$ parsecmgmt -a run -p parsec.bodytrack -i simlarge -n 4
[PARSEC] Benchmarks to run:  parsec.bodytrack

[PARSEC] [========== Running benchmark parsec.bodytrack [1] ==========]
[PARSEC] Deleting old run directory.
[PARSEC] Setting up run directory.
[PARSEC] Unpacking benchmark input 'simlarge'.
sequenceB_4/
sequenceB_4/BodyShapeParameters.txt
sequenceB_4/CALIB/
sequenceB_4/CALIB/Camera1.cal
sequenceB_4/CALIB/Camera2.cal
sequenceB_4/CALIB/Camera3.cal
sequenceB_4/CALIB/Camera4.cal
sequenceB_4/CAM1/
sequenceB_4/CAM1/image0000.bmp
sequenceB_4/CAM1/image0001.bmp
sequenceB_4/CAM1/image0002.bmp
sequenceB_4/CAM1/image0003.bmp
sequenceB_4/CAM2/
sequenceB_4/CAM2/image0000.bmp
sequenceB_4/CAM2/image0001.bmp
sequenceB_4/CAM2/image0002.bmp
sequenceB_4/CAM2/image0003.bmp
sequenceB_4/CAM3/
sequenceB_4/CAM3/image0000.bmp
sequenceB_4/CAM3/image0001.bmp
sequenceB_4/CAM3/image0002.bmp
sequenceB_4/CAM3/image0003.bmp
sequenceB_4/CAM4/
sequenceB_4/CAM4/image0000.bmp
sequenceB_4/CAM4/image0001.bmp
sequenceB_4/CAM4/image0002.bmp
sequenceB_4/CAM4/image0003.bmp
sequenceB_4/FG1/
sequenceB_4/FG1/image0000.bmp
sequenceB_4/FG1/image0001.bmp
sequenceB_4/FG1/image0002.bmp
sequenceB_4/FG1/image0003.bmp
sequenceB_4/FG2/
sequenceB_4/FG2/image0000.bmp
sequenceB_4/FG2/image0001.bmp
sequenceB_4/FG2/image0002.bmp
sequenceB_4/FG2/image0003.bmp
sequenceB_4/FG3/
sequenceB_4/FG3/image0000.bmp
sequenceB_4/FG3/image0001.bmp
sequenceB_4/FG3/image0002.bmp
sequenceB_4/FG3/image0003.bmp
sequenceB_4/FG4/
sequenceB_4/FG4/image0000.bmp
sequenceB_4/FG4/image0001.bmp
sequenceB_4/FG4/image0002.bmp
sequenceB_4/FG4/image0003.bmp
sequenceB_4/InitialPose.txt
sequenceB_4/PoseParameters.txt
[PARSEC] Running 'time /home/qflex/parsec-benchmark/pkgs/apps/bodytrack/inst/aarch64-linux.gcc/bin/bodytrack sequenceB_4 4 4 4000 5 0 4':
[PARSEC] [---------- Beginning of output ----------]
PARSEC Benchmark Suite Version 3.0-beta-20150206
Threading with Posix Threads
Number of threads : 4
Using dataset : sequenceB_4/
4000 particles with 5 annealing layers

Processing frame 0
Processing frame 1
Processing frame 2
Processing frame 3

real    1m36.820s
user    6m7.792s
sys     0m0.492s
[PARSEC] [----------    End of output    ----------]
[PARSEC]
[PARSEC] BIBLIOGRAPHY
[PARSEC]
[PARSEC] [1] Bienia. Benchmarking Modern Multiprocessors. Ph.D. Thesis, 2011.
[PARSEC]
[PARSEC] Done.
qflex@qflex:~/parsec-benchmark$

qflex@qflex:~/parsec-benchmark$ uname -a
Linux qflex 4.4.0-142-generic #168-Ubuntu SMP Wed Jan 16 21:00:53 UTC 2019 aarch64 aarch64 aarch64 GNU/Linux

qflex@qflex:~/parsec-benchmark$ gcc --version
gcc (Ubuntu/Linaro 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
