### PR TITLE
Fix building parsec.swaptions with pascal hooks failing with cannot find -lhooks: No such file or directory

### DIFF
--- a/config/gcc.bldconf
+++ b/config/gcc.bldconf
@@ -46,7 +46,7 @@ export CXXCPPFLAGS=""
 export LIBS=""
 export EXTRA_LIBS=""
 export PARMACS_MACRO_FILE="pthreads"
-
+export LDFLAGS=""
 # Add PARSEC version to compiler flags
 if [ -f "${PARSECDIR}/version" ]; then
   CFLAGS="${CFLAGS} -DPARSEC_VERSION=$(${CAT} ${PARSECDIR}/version)"

--- a/pkgs/apps/swaptions/src/HJM_Securities.cpp
+++ b/pkgs/apps/swaptions/src/HJM_Securities.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 #ifdef PARSEC_VERSION
 #define __PARSEC_STRING(x) #x
 #define __PARSEC_XSTRING(x) __PARSEC_STRING(x)
-        printf("PARSEC Benchmark Suite Version "__PARSEC_XSTRING(PARSEC_VERSION)"\n"); 
+        printf("PARSEC Benchmark Suite Version " __PARSEC_XSTRING(PARSEC_VERSION) "\n"); 
 	fflush(NULL);
 #else
         printf("PARSEC Benchmark Suite\n");


### PR DESCRIPTION
Hi cirosantilli , when I tried to compile the swaptions with gcc-hooks, I notice that LDFLAGS isn't exported, because that the makefile doesn't have the hook lib location
```bash
[samuel@Archlinux parsec-benchmark]$ parsecmgmt  -a build -p swaptions -c gcc-hooks
[PARSEC] Packages to build:  parsec.swaptions

[PARSEC] [========== Building package parsec.swaptions [1] ==========]
[PARSEC] [---------- Analyzing package parsec.swaptions ----------]
[PARSEC] parsec.swaptions depends on: hooks
[PARSEC] [---------- Analyzing package parsec.hooks ----------]
[PARSEC] Package parsec.hooks already exists, proceeding.
[PARSEC] [---------- Building package parsec.swaptions ----------]
[PARSEC] Removing old build directory.
[PARSEC] Copying source code of package parsec.swaptions.
[PARSEC] Running 'env version=pthreads make':

....

/usr/bin/g++  -fpermissive -fno-exceptions -DPARSEC_VERSION=3.0-beta-20150206 -DENABLE_PARSEC_HOOKS -I/home/samuel/Repositories/public/parsec-benchmark/pkgs/libs/hooks/inst/amd64-linux.gcc-hooks/include -pthread   -DENABLE_THREADS CumNormalInv.o MaxFunction.o RanUnif.o nr_routines.o icdf.o HJM_SimPath_Forward_Blocking.o HJM.o HJM_Swaption_Blocking.o HJM_Securities.o   -lhooks -o swaptions 
/usr/bin/ld: cannot find -lhooks: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:31: swaptions] Error 1
```
Exporting LDFLAGS make possible the makefile access location of hook lib.


Now it's possible compile swaptions with pascal-hooks

