### PR TITLE
Fix ferret default execution

### DIFF
--- a/pkgs/apps/ferret/src/benchmark/ferret-pthreads.c
+++ b/pkgs/apps/ferret/src/benchmark/ferret-pthreads.c
@@ -387,7 +387,7 @@ void *t_out (void *dummy)
 		ARRAY_BEGIN_FOREACH(rank->result.u.list, cass_list_entry_t p)
 		{
 			char *obj = NULL;
-			if (p.dist >= FLT_MAX) continue;
+			if (p.dist == FLT_MAX) continue;
 			cass_map_id_to_dataobj(query_table->map, p.id, &obj);
 			assert(obj != NULL);
 			fprintf(fout, "\t%s:%g", obj, p.dist);

--- a/pkgs/apps/ferret/src/benchmark/ferret-pthreads.c
+++ b/pkgs/apps/ferret/src/benchmark/ferret-pthreads.c
@@ -387,7 +387,7 @@ void *t_out (void *dummy)
 		ARRAY_BEGIN_FOREACH(rank->result.u.list, cass_list_entry_t p)
 		{
 			char *obj = NULL;
-			if (p.dist == HUGE_VAL) continue;
+			if (p.dist >= FLT_MAX) continue;
 			cass_map_id_to_dataobj(query_table->map, p.id, &obj);
 			assert(obj != NULL);
 			fprintf(fout, "\t%s:%g", obj, p.dist);

--- a/pkgs/apps/ferret/src/benchmark/ferret-serial.c
+++ b/pkgs/apps/ferret/src/benchmark/ferret-serial.c
@@ -220,7 +220,7 @@ void do_query (const char *name)
 	ARRAY_BEGIN_FOREACH(result.u.list, cass_list_entry_t p)
 	{
 		char *obj = NULL;
-		if (p.dist == HUGE_VAL) continue;
+		if (p.dist == FLT_MAX) continue;
 		cass_map_id_to_dataobj(query_table->map, p.id, &obj);
 		assert(obj != NULL);
 		fprintf(fout, "\t%s:%g", obj, p.dist);

--- a/pkgs/apps/ferret/src/benchmark/ferret-tbb.cpp
+++ b/pkgs/apps/ferret/src/benchmark/ferret-tbb.cpp
@@ -404,7 +404,7 @@ void *filter_out::operator()(void* item) {
 	ARRAY_BEGIN_FOREACH(data->first.rank.result.u.list, cass_list_entry_t p)
 	{
 		char *obj = NULL;
-		if (p.dist == HUGE_VAL) continue;
+		if (p.dist == FLT_MAX) continue;
 		cass_map_id_to_dataobj(query_table->map, p.id, &obj);
 		assert(obj != NULL);
 		fprintf(fout, "\t%s:%g", obj, p.dist);

--- a/pkgs/apps/ferret/src/src/lsh/LSH_query.c
+++ b/pkgs/apps/ferret/src/src/lsh/LSH_query.c
@@ -55,6 +55,7 @@ void LSH_query_init (LSH_query_t *query, LSH_t *lsh, cass_dataset_t *ds, cass_si
 		ptb_vec_t *scr = gen_score(query->lsh->M);
 		assert(scr != NULL);
 		query->ptb_set = type_calloc(ptb_vec_t, T);
+		if (T != 0) 
 		assert(query->ptb_set != NULL);
 		gen_perturb_set(scr, query->ptb_set, query->lsh->M, T);
 		query->ptb_vec = type_matrix_alloc(ptb_vec_t, L, T);
@@ -197,7 +198,7 @@ static void LSH_query_local (LSH_query_t *query)
 	sx = sy = sxx = sxy = 0.0;
 	for (j = 0; j < K-1; j++)
 	{
-		if (query->topk[K - j - 2].dist >= HUGE_VAL) break;
+		if (query->topk[K - j - 2].dist >= FLT_MAX) break;
 		lk = log(j+1); 
 		ld = log(query->topk[K - j - 2].dist);
 		sx += lk;
@@ -243,7 +244,7 @@ static void LSH_query_bootstrap (LSH_query_t *query, const float *point)
 	for (i = 0; i < L; i++)
 	{
 		memset(_topk[i], 0xff, sizeof (*_topk[i]) * K);
-		TOPK_INIT(_topk[i], dist, K, HUGE_VAL);
+		TOPK_INIT(_topk[i], dist, K, FLT_MAX);
 		ARRAY_BEGIN_FOREACH(lsh->hash[i].bucket[tmp2[i]], uint32_t id) {
 			if (!bitmap_contain(query->bitmap, id))
 			{
@@ -358,7 +359,7 @@ void LSH_query_merge (LSH_query_t *query)
 	int i, j;
 
 	memset(topk, 0xff, sizeof (*topk) * K);
-	TOPK_INIT(topk, dist, K, HUGE_VAL);
+	TOPK_INIT(topk, dist, K, FLT_MAX);
 
 //	query->CC = 0;
 

--- a/pkgs/apps/ferret/src/src/lsh/LSH_query_batch.c
+++ b/pkgs/apps/ferret/src/src/lsh/LSH_query_batch.c
@@ -139,7 +139,7 @@ void LSH_query_batch (const LSH_query_t *query, int N, const float **point, cass
 		}
 		LSH_hash2_noperturb(lsh, tmp, tmp2, L);
 
-		TOPK_INIT(topk[i], dist, K, HUGE_VAL);
+		TOPK_INIT(topk[i], dist, K, FLT_MAX);
 		for (j = 0; j < L; j++)
 		{
 			int k;
@@ -320,9 +320,9 @@ void LSH_query_batch_ca (const LSH_query_t *query, int N, const float **point, c
 	for (i = 0; i < N; i++)
 	{
 		int j;
-		TOPK_INIT(topk[i], dist, K, HUGE_VAL);
+		TOPK_INIT(topk[i], dist, K, FLT_MAX);
 		for (j = 0; j < T; j++)
-			TOPK_INIT(ptopk[i][j], dist, K, HUGE_VAL);
+			TOPK_INIT(ptopk[i][j], dist, K, FLT_MAX);
 	}
 
 	//stimer_tuck(&tmr, "Stage-2");

--- a/pkgs/apps/ferret/src/src/matrix.c
+++ b/pkgs/apps/ferret/src/src/matrix.c
@@ -95,6 +95,7 @@ void **__matrix_alloc (cass_size_t row, cass_size_t col, cass_size_t size)
 	void **idx = (void **)malloc((row + 1)* sizeof (void *));
 	assert(idx != NULL);
 	idx[0] = calloc(row * col, size);
+	if (row * col != 0)	
 	assert(idx[0] != NULL);
 	for (i = 1; i <= row; i++)
 	{


### PR DESCRIPTION
Currently, running `parsecmgmt -a run -p ferret` gives segmentation fault.

1. Replace `HUGE_VAL` by `FLT_MAX`
`HUGE_VAL` gives an positive infinite number, which is not guaranteed to be supported.
2. Assert not NULL only if the allocated size is not 0
malloc/realloc 0 returns NULL or a pointer cannot be dereferenced, NULL is a valid return.