### PR TITLE
Fix various compile issues on ubuntu 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.tar
 *.tar.gz
 *~
+*.swp
 /log
 /parsec-3.0
 /pkgs/libs/gsl/src/doc/gsl-ref.info*

--- a/ext/splash2/apps/barnes/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/barnes/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC "
+build_env="version=IN_PARSEC CFLAGS=-fcommon "
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/fmm/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/fmm/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/ocean_cp/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/ocean_cp/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/ocean_ncp/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/ocean_ncp/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/radiosity/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/radiosity/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/raytrace/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/raytrace/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/volrend/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/volrend/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/water_nsquared/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/water_nsquared/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2/apps/water_spatial/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2/apps/water_spatial/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps=""
 
 # Environment to use for configure script and Makefile
-build_env="version=IN_PARSEC"
+build_env="version=IN_PARSEC CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/ext/splash2x/apps/raytrace/parsec/gcc-pthreads.bldconf
+++ b/ext/splash2x/apps/raytrace/parsec/gcc-pthreads.bldconf
@@ -18,7 +18,7 @@
 build_deps="parmacs"
 
 # Environment to use for configure script and Makefile
-build_env="version=pthreads"
+build_env="version=pthreads CFLAGS=-fcommon"
 
 # Whether the build system supports only in-place compilation.
 # If TRUE, then all sources will be copied to the build directory before we

--- a/pkgs/libs/tbblib/src/src/tbbmalloc/proxy.cpp
+++ b/pkgs/libs/tbblib/src/src/tbbmalloc/proxy.cpp
@@ -157,7 +157,7 @@ extern "C" struct mallinfo mallinfo() __THROW
 
 #include <new>
 
-void * operator new(size_t sz) throw (std::bad_alloc) {
+void * operator new(size_t sz) /*throw (std::bad_alloc)*/ {
     void *res = scalable_malloc(sz);
 #if TBB_USE_EXCEPTIONS
     if (NULL == res)
@@ -165,7 +165,7 @@ void * operator new(size_t sz) throw (std::bad_alloc) {
 #endif /* TBB_USE_EXCEPTIONS */
     return res;
 }
-void* operator new[](size_t sz) throw (std::bad_alloc) {
+void* operator new[](size_t sz) /*throw (std::bad_alloc)*/ {
     void *res = scalable_malloc(sz);
 #if TBB_USE_EXCEPTIONS
     if (NULL == res)


### PR DESCRIPTION
Only tested in ubuntu 22.04 with gcc 11.3.0.
Fix one c++ dynamic exception specification issue.
Fix one c tentative variable definition issue (exists in multiple splash apps).