### PR TITLE
flush at end of bench

### DIFF
--- a/pkgs/libs/hooks/src/hooks.c
+++ b/pkgs/libs/hooks/src/hooks.c
@@ -164,7 +164,7 @@ void __parsec_bench_end() {
   #endif //DEBUG
 
   #if ENABLE_TIMING
-  printf(HOOKS_PREFIX" Total time spent in ROI: %.3fs\n", time_end-time_begin);
+  printf(HOOKS_PREFIX" Total time spent in ROI: %.6fs\n", time_end-time_begin);
   #endif //ENABLE_TIMING
   printf(HOOKS_PREFIX" Terminating\n");
   fflush(NULL);

--- a/pkgs/libs/hooks/src/hooks.c
+++ b/pkgs/libs/hooks/src/hooks.c
@@ -163,11 +163,11 @@ void __parsec_bench_end() {
   assert(num_bench_ends==1);
   #endif //DEBUG
 
-  fflush(NULL);
   #if ENABLE_TIMING
   printf(HOOKS_PREFIX" Total time spent in ROI: %.3fs\n", time_end-time_begin);
   #endif //ENABLE_TIMING
   printf(HOOKS_PREFIX" Terminating\n");
+  fflush(NULL);
 }
 
 void __parsec_roi_begin() {


### PR DESCRIPTION
I've been observing cases where the total ROI time (which is quite important) is not printed in gem5. Example output for fft:

```
[HOOKS] PARSEC Hooks Version 1.2

FFT with Blocking Transpose
   1024 Complex Doubles
   1 Processors
   65536 Cache lines
   16 Byte line size
   4096 Bytes per page

[HOOKS] Entering ROI
iter_num = 32
Transpose: iter_num = 0
Step 1:       43
FFt1DOnce: iter_num = 80
Step 2:      193
Transpose: iter_num = 0
Step 3:       44
Step 4:      158
Transpose: iter_num = 0
Step 5:       43
[HOOKS] Leaving ROI

                 PROCESS STATISTICS
            Computation      Transpose     Transpose
 Proc          Time            Time        Fraction
    0               505            130       0.25743

                 TIMING INFORMATION
Start time                        : 1000000000000189
Initialization finish time        : 1000000000000389
Overall finish time               : 1000000000000894
Total time with initialization    :              705
Total time without initialization :              505
Overall transpose time            :              130
Overall transpose fraction        :          0.25743
```

