### PR TITLE
Print total time spent in ROI in splash2x

### DIFF
--- a/clean-build.sh
+++ b/clean-build.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-git clean -xdf -e parsec-3.0-core.tar.gz -e parsec-3.0-input-sim.tar.gz -e parsec-3.0-input-native.tar.gz .
+git clean -xdf -e parsec-3.0-core.tar.gz -e parsec-3.0-input-sim.tar.gz -e parsec-3.0-input-native.tar.gz -e inputs .

--- a/ext/splash2x/apps/barnes/src/code.C
+++ b/ext/splash2x/apps/barnes/src/code.C
@@ -305,11 +305,12 @@ int main (int argc, string argv[])
 	  ((float)(Global->tracktime-Global->partitiontime-
 		   Global->treebuildtime-Global->forcecalctime))/
 	  Global->tracktime);
-   MAIN_END;
 
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+   __parsec_bench_end();
 #endif
+
+   MAIN_END;
 }
 
 /*

--- a/ext/splash2x/apps/fmm/src/fmm.C
+++ b/ext/splash2x/apps/fmm/src/fmm.C
@@ -160,10 +160,12 @@ int main (int argc, char *argv[])
    if (do_output) {
      PrintAllParticles();
    }
-   MAIN_END;
+
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+   __parsec_bench_end();
 #endif
+
+   MAIN_END;
 }
 
 

--- a/ext/splash2x/apps/ocean_cp/src/main.C
+++ b/ext/splash2x/apps/ocean_cp/src/main.C
@@ -546,10 +546,11 @@ int main(int argc, char *argv[])
    printf("    (excludes first timestep)\n");
    printf("\n");
 
-   MAIN_END
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 long log_2(long number)

--- a/ext/splash2x/apps/ocean_ncp/src/main.C
+++ b/ext/splash2x/apps/ocean_ncp/src/main.C
@@ -514,10 +514,11 @@ int main(int argc, char *argv[])
    printf("    (excludes first timestep)\n");
    printf("\n");
 
-   MAIN_END
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 long log_2(long number)

--- a/ext/splash2x/apps/radiosity/src/rad_main.C
+++ b/ext/splash2x/apps/radiosity/src/rad_main.C
@@ -336,10 +336,12 @@ int main(int argc, char *argv[])
             g_start( expose_callback,
                     N_SLIDERS, sliders, N_CHOICES, choices ) ;
         }
-    MAIN_END;
+
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+    __parsec_bench_end();
 #endif
+
+    MAIN_END;
     exit(0) ;
 }
 

--- a/ext/splash2x/apps/volrend/src/main.C
+++ b/ext/splash2x/apps/volrend/src/main.C
@@ -109,10 +109,11 @@ int main(int argc, char *argv[])
 #endif
   }
 
-  MAIN_END;
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 

--- a/ext/splash2x/apps/water_nsquared/src/water.C
+++ b/ext/splash2x/apps/water_nsquared/src/water.C
@@ -273,10 +273,11 @@ int main(int argc, char **argv)
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 
-    MAIN_END;
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+    __parsec_bench_end();
 #endif
+
+    MAIN_END;
 } /* main.c */
 
 void WorkStart() /* routine that each created process starts at;

--- a/ext/splash2x/apps/water_spatial/src/water.C
+++ b/ext/splash2x/apps/water_spatial/src/water.C
@@ -367,10 +367,11 @@ int main(int argc, char **argv)
 
     printf("\nExited Happily with XTT = %g (note: XTT value is garbage if NPRINT > NSTEP)\n", XTT);
 
-    MAIN_END;
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+    __parsec_bench_end();
 #endif
+
+    MAIN_END;
 } /* main.c */
 
 void WorkStart() /* routine that each created process starts at;

--- a/ext/splash2x/kernels/cholesky/src/solve.C
+++ b/ext/splash2x/kernels/cholesky/src/solve.C
@@ -323,11 +323,11 @@ int main(int argc, char *argv[])
     }
   }
 
-  MAIN_END
-
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 
 }
 

--- a/ext/splash2x/kernels/fft/src/fft.C
+++ b/ext/splash2x/kernels/fft/src/fft.C
@@ -428,11 +428,11 @@ int main(int argc, char *argv[])
     }
   }
 
-  MAIN_END;
-
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 

--- a/ext/splash2x/kernels/lu_cb/src/lu.C
+++ b/ext/splash2x/kernels/lu_cb/src/lu.C
@@ -411,10 +411,11 @@ int main(int argc, char *argv[])
     CheckResult(n, a, rhs);
   }
 
-  MAIN_END;
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 

--- a/ext/splash2x/kernels/lu_ncb/src/lu.C
+++ b/ext/splash2x/kernels/lu_ncb/src/lu.C
@@ -321,10 +321,11 @@ int main(int argc, char *argv[])
     CheckResult(n, a, rhs);
   }
 
-  MAIN_END;
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 void SlaveStart()

--- a/ext/splash2x/kernels/radix/src/radix.C
+++ b/ext/splash2x/kernels/radix/src/radix.C
@@ -395,11 +395,12 @@ int main(int argc, char *argv[])
    if (test_result) {
      test_sort(global->final);  
    }
-  
-   MAIN_END;
+
 #ifdef ENABLE_PARSEC_HOOKS
-	__parsec_bench_end();
+  __parsec_bench_end();
 #endif
+
+  MAIN_END;
 }
 
 void slave_sort()

--- a/pkgs/libs/hooks/src/hooks.c
+++ b/pkgs/libs/hooks/src/hooks.c
@@ -165,7 +165,7 @@ void __parsec_bench_end() {
 
   fflush(NULL);
   #if ENABLE_TIMING
-  printf(HOOKS_PREFIX" Total time spent in ROI: %.3fs\n", time_end-time_begin);
+  printf(HOOKS_PREFIX" Total time spent in ROI: %.6fs\n", time_end-time_begin);
   #endif //ENABLE_TIMING
   printf(HOOKS_PREFIX" Terminating\n");
 }


### PR DESCRIPTION
How to reproduce: `parsecmgmt -a run -p splash2x.fft -i test`.
Current behavior: `[HOOKS] Total time spent in ROI: ` is not present in output.
After the changes, you should see `[HOOKS] Total time spent in ROI: ` in output.